### PR TITLE
feat: add order by for get orders

### DIFF
--- a/constant/order_by_constants.go
+++ b/constant/order_by_constants.go
@@ -1,0 +1,6 @@
+package constant
+
+var (
+	SortArray      = []string{"order_id", "origin_network", "from_address", "amount", "status", "created_at", "transferred_at", "completed_at"}
+	DirectionArray = []string{"asc", "desc"}
+)

--- a/controllers/order_controller.go
+++ b/controllers/order_controller.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
+	"yab-explorer/constant"
 	"yab-explorer/services"
 
 	"github.com/gin-gonic/gin"
@@ -48,6 +50,8 @@ func (o OrderControllerImpl) GetOrder(c *gin.Context) {
 func (o OrderControllerImpl) GetOrders(c *gin.Context) {
 	pageStr := c.DefaultQuery("page", "1")
 	pageSizeStr := c.DefaultQuery("pageSize", "10")
+	sortBy := c.DefaultQuery("sortBy", "order_id")
+	direction := c.DefaultQuery("direction", "desc")
 
 	page, err := strconv.Atoi(pageStr)
 	if err != nil {
@@ -71,7 +75,17 @@ func (o OrderControllerImpl) GetOrders(c *gin.Context) {
 		return
 	}
 
-	orders, err := o.service.GetOrders(page, pageSize)
+	if !slices.Contains[[]string](constant.SortArray, sortBy) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid sortBy parameter"})
+		return
+	}
+
+	if !slices.Contains[[]string](constant.DirectionArray, direction) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid direction parameter"})
+		return
+	}
+
+	orders, err := o.service.GetOrders(page, pageSize, sortBy, direction)
 
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get orders"})

--- a/controllers/order_controller.go
+++ b/controllers/order_controller.go
@@ -50,7 +50,7 @@ func (o OrderControllerImpl) GetOrder(c *gin.Context) {
 func (o OrderControllerImpl) GetOrders(c *gin.Context) {
 	pageStr := c.DefaultQuery("page", "1")
 	pageSizeStr := c.DefaultQuery("pageSize", "10")
-	sortBy := c.DefaultQuery("sortBy", "order_id")
+	sortBy := c.DefaultQuery("sort", "order_id")
 	direction := c.DefaultQuery("direction", "desc")
 
 	page, err := strconv.Atoi(pageStr)

--- a/models/order.go
+++ b/models/order.go
@@ -6,7 +6,7 @@ type Order struct {
 	OrderId          int        `gorm:"column:order_id;primaryKey" json:"order_id"`
 	OriginNetwork    string     `gorm:"column:origin_network;not null;primaryKey" json:"origin_network"`
 	RecipientAddress string     `gorm:"column:recipient_address;not null;size:42" json:"recipient_address"`
-	FromAddress      string     `gorm:"column:recipient_address;not null;size:42" json:"from_address"`
+	FromAddress      string     `gorm:"column:from_address;not null;size:42" json:"from_address"`
 	Amount           string     `gorm:"column:amount;not null" json:"amount"`
 	Fee              string     `gorm:"column:fee;not null" json:"fee"`
 	Status           string     `gorm:"column:status;not null;default:PENDING" json:"status"`

--- a/repository/order_repository.go
+++ b/repository/order_repository.go
@@ -10,7 +10,7 @@ import (
 
 type OrderRepository interface {
 	GetOrder(id int) (models.Order, error)
-	GetOrders(page, pageSize int) ([]models.Order, error)
+	GetOrders(page, pageSize int, sortBy, direction string) ([]models.Order, error)
 	GetTotalOrders() (int, error)
 }
 
@@ -32,11 +32,12 @@ func (o OrderRepositoryImpl) GetOrder(id int) (models.Order, error) {
 	return order, nil
 }
 
-func (o OrderRepositoryImpl) GetOrders(page, pageSize int) ([]models.Order, error) {
+func (o OrderRepositoryImpl) GetOrders(page, pageSize int, sortBy, direction string) ([]models.Order, error) {
 	var orders []models.Order
-	err := o.db.Limit(pageSize).Offset((page - 1) * pageSize).Order("created_at desc").Find(&orders).Error
+	orderByStr := sortBy + " " + direction
+	err := o.db.Limit(pageSize).Offset((page - 1) * pageSize).Order(orderByStr).Find(&orders).Error
 	if err != nil {
-		log.Error("Error getting orders with page: ", page, " and pageSize: ", pageSize, " in OrderRepositoryImpl. Error: ", err)
+		log.Error("Error getting orders with page: ", page, " and pageSize: ", pageSize, " with sortBy: ", sortBy, " and direction: ", direction, " in OrderRepositoryImpl. Error: ", err)
 		return nil, err
 	}
 	return orders, nil

--- a/services/order_service.go
+++ b/services/order_service.go
@@ -9,7 +9,7 @@ import (
 
 type OrderService interface {
 	GetOrder(orderId int) (models.Order, error)
-	GetOrders(page, pageSize int) ([]models.Order, error)
+	GetOrders(page, pageSize int, sortBy, direction string) ([]models.Order, error)
 	GetTotalOrders() (int, error)
 }
 
@@ -31,11 +31,11 @@ func (o OrderServiceImpl) GetOrder(orderId int) (models.Order, error) {
 	return order, nil
 }
 
-func (o OrderServiceImpl) GetOrders(page, pageSize int) ([]models.Order, error) {
-	log.Info("Called GetOrders with page: ", page, " and pageSize: ", pageSize, " in OrderServiceImpl.")
-	orders, err := o.orderRepository.GetOrders(page, pageSize)
+func (o OrderServiceImpl) GetOrders(page, pageSize int, sortBy, direction string) ([]models.Order, error) {
+	log.Info("Called GetOrders with page: ", page, " and pageSize: ", pageSize, " with sortBy: ", sortBy, " and direction: ", direction, " in OrderServiceImpl.")
+	orders, err := o.orderRepository.GetOrders(page, pageSize, sortBy, direction)
 	if err != nil {
-		log.Error("Error getting orders with page: ", page, " and pageSize: ", pageSize, " in OrderServiceImpl. Error: ", err)
+		log.Error("Error getting orders with page: ", page, " and pageSize: ", pageSize, " with sortBy: ", sortBy, " and direction: ", direction, " in OrderServiceImpl. Error: ", err)
 		return []models.Order{}, err
 	}
 	return orders, nil


### PR DESCRIPTION
GET /orders now allows sort and direction query params:

The system is able to sort by the following fields:

- OrderId -> order_id
- OriginNetwork -> origin_network
- FromAddress -> from_address
- Amount -> amount
- Status -> status
- CreatedAt -> created_at
- TransferredAt -> transferred_at
- CompletedAt -> completed_at

The query param format is snake case

And the system is able to set direction ASC or DESC (the accepted params are in lower case)

> [!IMPORTANT]
> Sorting by from_address will return a 500 error due to the fact that the database does not have the from_address column (yet)