### PR TITLE
fix: make logrus output to stdout

### DIFF
--- a/configs/logger.go
+++ b/configs/logger.go
@@ -18,6 +18,7 @@ func InitLog() {
 		ShowFullLevel:   true,
 		CallerFirst:     true,
 	})
+	log.SetOutput(os.Stdout)
 }
 
 func getLoggerLevel(level string) log.Level {


### PR DESCRIPTION
## Description
- Change Logrus output from stderr to stdout. By default it was stderr.
## Results
- This PR changes the Logrus output from stderr to stdout.